### PR TITLE
fix: read language from company.json instead of hardcoding "de"

### DIFF
--- a/examples/digitalagentur/templates/common/styles.typ
+++ b/examples/digitalagentur/templates/common/styles.typ
@@ -127,6 +127,10 @@
   }
 }
 
+#let get-language(company) = {
+  if company != none and "language" in company { company.language } else { "de" }
+}
+
 #let color-secondary = rgb("#34495e")
 #let color-text = rgb("#2c3e50")
 #let color-text-light = rgb("#7f8c8d")

--- a/examples/digitalagentur/templates/concept/default.typ
+++ b/examples/digitalagentur/templates/concept/default.typ
@@ -104,7 +104,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/digitalagentur/templates/credentials/default.typ
+++ b/examples/digitalagentur/templates/credentials/default.typ
@@ -79,7 +79,7 @@
   }
 )
 
-#set text(font: fonts.body, size: size-medium, lang: "de")
+#set text(font: fonts.body, size: size-medium, lang: get-language(company))
 #set par(justify: true, leading: 0.65em)
 
 // Heading styles

--- a/examples/digitalagentur/templates/documentation/default.typ
+++ b/examples/digitalagentur/templates/documentation/default.typ
@@ -61,7 +61,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/digitalagentur/templates/invoice/default.typ
+++ b/examples/digitalagentur/templates/invoice/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/examples/digitalagentur/templates/offer/default.typ
+++ b/examples/digitalagentur/templates/offer/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/examples/freelance-designer/templates/common/styles.typ
+++ b/examples/freelance-designer/templates/common/styles.typ
@@ -127,6 +127,10 @@
   }
 }
 
+#let get-language(company) = {
+  if company != none and "language" in company { company.language } else { "de" }
+}
+
 #let color-secondary = rgb("#34495e")
 #let color-text = rgb("#2c3e50")
 #let color-text-light = rgb("#7f8c8d")

--- a/examples/freelance-designer/templates/concept/default.typ
+++ b/examples/freelance-designer/templates/concept/default.typ
@@ -104,7 +104,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/freelance-designer/templates/credentials/default.typ
+++ b/examples/freelance-designer/templates/credentials/default.typ
@@ -79,7 +79,7 @@
   }
 )
 
-#set text(font: fonts.body, size: size-medium, lang: "de")
+#set text(font: fonts.body, size: size-medium, lang: get-language(company))
 #set par(justify: true, leading: 0.65em)
 
 // Heading styles

--- a/examples/freelance-designer/templates/documentation/default.typ
+++ b/examples/freelance-designer/templates/documentation/default.typ
@@ -61,7 +61,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/freelance-designer/templates/invoice/default.typ
+++ b/examples/freelance-designer/templates/invoice/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/examples/freelance-designer/templates/offer/default.typ
+++ b/examples/freelance-designer/templates/offer/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/examples/it-consultant/templates/common/styles.typ
+++ b/examples/it-consultant/templates/common/styles.typ
@@ -127,6 +127,10 @@
   }
 }
 
+#let get-language(company) = {
+  if company != none and "language" in company { company.language } else { "de" }
+}
+
 #let color-secondary = rgb("#34495e")
 #let color-text = rgb("#2c3e50")
 #let color-text-light = rgb("#7f8c8d")

--- a/examples/it-consultant/templates/concept/default.typ
+++ b/examples/it-consultant/templates/concept/default.typ
@@ -104,7 +104,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/it-consultant/templates/credentials/default.typ
+++ b/examples/it-consultant/templates/credentials/default.typ
@@ -79,7 +79,7 @@
   }
 )
 
-#set text(font: fonts.body, size: size-medium, lang: "de")
+#set text(font: fonts.body, size: size-medium, lang: get-language(company))
 #set par(justify: true, leading: 0.65em)
 
 // Heading styles

--- a/examples/it-consultant/templates/documentation/default.typ
+++ b/examples/it-consultant/templates/documentation/default.typ
@@ -61,7 +61,7 @@
     ]
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/examples/it-consultant/templates/invoice/default.typ
+++ b/examples/it-consultant/templates/invoice/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/examples/it-consultant/templates/offer/default.typ
+++ b/examples/it-consultant/templates/offer/default.typ
@@ -112,7 +112,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/templates/common/styles.typ
+++ b/templates/common/styles.typ
@@ -127,6 +127,10 @@
   }
 }
 
+#let get-language(company) = {
+  if company != none and "language" in company { company.language } else { "de" }
+}
+
 #let color-secondary = rgb("#34495e")
 #let color-text = rgb("#2c3e50")
 #let color-text-light = rgb("#7f8c8d")

--- a/templates/concept/default.typ
+++ b/templates/concept/default.typ
@@ -96,7 +96,7 @@
     } } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/templates/contract/default.typ
+++ b/templates/contract/default.typ
@@ -58,7 +58,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "§1.")
 

--- a/templates/credentials/default.typ
+++ b/templates/credentials/default.typ
@@ -94,7 +94,7 @@
   }
 )
 
-#set text(font: fonts.body, size: size-medium, lang: "de")
+#set text(font: fonts.body, size: size-medium, lang: get-language(company))
 #set par(justify: true, leading: 0.65em)
 
 // Heading styles

--- a/templates/credit-note/default.typ
+++ b/templates/credit-note/default.typ
@@ -22,7 +22,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Logo and metadata header
 #accounting-header(

--- a/templates/delivery-note/default.typ
+++ b/templates/delivery-note/default.typ
@@ -20,7 +20,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Logo and metadata header
 #accounting-header(

--- a/templates/diagram/default.typ
+++ b/templates/diagram/default.typ
@@ -6,6 +6,8 @@
   none
 }
 
+#let company = if "company" in sys.inputs { json(sys.inputs.company) } else { (:) }
+
 #let page-width = data.document.width_pt * 1pt
 #let page-height = data.document.height_pt * 1pt
 #let title = data.diagram.title
@@ -18,7 +20,7 @@
   fill: rgb(data.document.background),
 )
 
-#set text(font: "Inter", size: 10pt, lang: "de")
+#set text(font: "Inter", size: 10pt, lang: get-language(company))
 
 #let draw-segment(segment, color) = place(
   top + left,

--- a/templates/documentation/default.typ
+++ b/templates/documentation/default.typ
@@ -76,7 +76,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/templates/handout/default.typ
+++ b/templates/handout/default.typ
@@ -61,7 +61,7 @@
   let cat-light = cat-color.lighten(92%)
   let cat-mid = cat-color.lighten(80%)
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
 
   // Links

--- a/templates/invoice/default.typ
+++ b/templates/invoice/default.typ
@@ -26,7 +26,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/templates/letter/default.typ
+++ b/templates/letter/default.typ
@@ -24,7 +24,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/templates/offer/default.typ
+++ b/templates/offer/default.typ
@@ -25,7 +25,7 @@
 #set text(
   font: "Helvetica",
   size: 10pt,
-  lang: "de"
+  lang: company.language
 )
 
 // ============================================================================

--- a/templates/order-confirmation/default.typ
+++ b/templates/order-confirmation/default.typ
@@ -22,7 +22,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Logo and metadata
 #accounting-header(

--- a/templates/proposal/default.typ
+++ b/templates/proposal/default.typ
@@ -63,7 +63,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/templates/protocol/default.typ
+++ b/templates/protocol/default.typ
@@ -57,7 +57,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.")
 

--- a/templates/quotation-request/default.typ
+++ b/templates/quotation-request/default.typ
@@ -19,7 +19,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Header with logo and metadata
 #accounting-header(

--- a/templates/reminder/default.typ
+++ b/templates/reminder/default.typ
@@ -20,7 +20,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Logo and Metadata
 #accounting-header(

--- a/templates/sla/default.typ
+++ b/templates/sla/default.typ
@@ -62,7 +62,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/templates/specification/default.typ
+++ b/templates/specification/default.typ
@@ -63,7 +63,7 @@
     ) } else { none }
   )
 
-  set text(font: fonts.body, size: size-medium, lang: "de")
+  set text(font: fonts.body, size: size-medium, lang: get-language(company))
   set par(justify: true, leading: 0.65em)
   set heading(numbering: "1.1")
 

--- a/templates/task-list/default.typ
+++ b/templates/task-list/default.typ
@@ -102,7 +102,7 @@
   set text(
     font: fonts.body,
     size: size-medium,
-    lang: "de"
+    lang: get-language(company)
   )
   
   set par(justify: true, leading: 0.65em)

--- a/templates/time-sheet/default.typ
+++ b/templates/time-sheet/default.typ
@@ -39,7 +39,7 @@
   footer: if show-footer { accounting-footer(company: company) }
 )
 
-#set text(font: "Helvetica", size: 10pt, lang: "de")
+#set text(font: "Helvetica", size: 10pt, lang: company.language)
 
 // Header with logo and metadata
 #accounting-header(


### PR DESCRIPTION
Closes #1

## Summary
- Add `get-language(company)` helper to `templates/common/styles.typ` and the three example copies — mirrors the existing `get-font-preset` / `get-accent-color` pattern
- Templates with a direct `json("/data/company.json")` load use `company.language` directly
- Function-based templates (concept, documentation, credentials, …) use `get-language(company)`, which falls back to `"de"` when `company` is absent or missing the field
- Diagram template now conditionally loads company from `sys.inputs.company` so it also respects the configured language
- 35 template files updated across `templates/` and `examples/`